### PR TITLE
cmake cleanup

### DIFF
--- a/src/plugins/CDAQfile/CMakeLists.txt
+++ b/src/plugins/CDAQfile/CMakeLists.txt
@@ -1,24 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
 
-# TODO: updae to match example_evio_analysis
+# Automatically set plugin name the same as the directory name
+# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing
 
-cmake_minimum_required(VERSION 3.9)
-project(CDAQfile)
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME} )
 
-# Manually manage source file list
-set(SRC_FILES
-        CDAQfile.cc
-        CDAQEVIOFileSource.h
-        ../../libraries/evio/HDEVIO.h
-        ../../libraries/evio/HDEVIO.cc
-        ../../libraries/evio/DModuleType.h
-        ../../extensions/spdlog/SpdlogMixin.h)
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
 
-add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
+# Add cern root
+plugin_add_cern_root(${PLUGIN_NAME})
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} ${JANA_LIB} ${ROOT_LIBRARIES} evio)
-set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" OUTPUT_NAME ${PROJECT_NAME} SUFFIX ".so")
-
-install(TARGETS ${PROJECT_NAME} DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
-
-
+# Add additional libraries
+target_link_libraries(${PLUGIN_NAME}_plugin evio)

--- a/src/plugins/CDAQtcp/CMakeLists.txt
+++ b/src/plugins/CDAQtcp/CMakeLists.txt
@@ -1,55 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
 
-cmake_minimum_required(VERSION 3.9)
-project(janaTCP_project)
+# Automatically set plugin name the same as the directory name
+# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)   # Enable -fPIC for all targets
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME} )
 
-# Expose custom cmake modules
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
 
-# Set install directory to $JANA_HOME
-set(CMAKE_INSTALL_PREFIX $ENV{JANA_HOME} CACHE PATH "magic incantation" FORCE)
+# Add cern root
+plugin_add_cern_root(${PLUGIN_NAME})
 
-# Find dependencies
-find_package(JANA REQUIRED)
-
-
-find_package(ROOT REQUIRED)
-
-# According to the internet, CMake authors discourage the use
-# of GLOB for identifying source files. IMHO, this is due to
-# the flawed use of cache files in CMake itself. Here, GLOB
-# is used as the default. What this means is you can add source
-# files and re-run cmake (after clearing the cache file) and
-# they will be found without needing to modify this file.
-# You also have the option of switching the following to "false"
-# and managing the source file list manually the way they recommend.
-if(true)
-  # Automatically determine source file list.
-  file(GLOB mysourcefiles *.cpp *.cc *.c  *.hpp *.hh *.h)
-  set( janaTCP_PLUGIN_SOURCES ${mysourcefiles} )    
-else()
-  # Manually manage source file list
-  set (janaTCP_PLUGIN_SOURCES
-        janaTCP.cc
-  )
-endif()
-
-add_library(janaTCP_plugin SHARED ${janaTCP_PLUGIN_SOURCES})
-
-target_include_directories(janaTCP_plugin PUBLIC ${CMAKE_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS})
-target_link_libraries(janaTCP_plugin ${JANA_LIB} ${ROOT_LIBRARIES})
-set_target_properties(janaTCP_plugin PROPERTIES PREFIX "" OUTPUT_NAME "janaTCP" SUFFIX ".so")
-
-install(TARGETS janaTCP_plugin DESTINATION plugins)
-
-file(GLOB my_headers "*.h*")
-install(FILES ${my_headers} DESTINATION include/janaTCP)
-
-# For root dictionaries
-file(GLOB my_pcms "${CMAKE_CURRENT_BINARY_DIR}/*.pcm")
-install(FILES ${my_pcms} DESTINATION plugins)
-
+# Add additional libraries
+target_link_libraries(${PLUGIN_NAME}_plugin tcp_daq evio)

--- a/src/plugins/CDAQtcp/JEventSourceCDAQtcp.h
+++ b/src/plugins/CDAQtcp/JEventSourceCDAQtcp.h
@@ -21,9 +21,9 @@ public:
     
     static std::string GetDescription();
     
-    int m_port;
     std::string m_remote_host;
     int m_sd;
+    int m_sd_current;
 
 };
 

--- a/src/plugins/CDAQtcp/tcp_thread.cc
+++ b/src/plugins/CDAQtcp/tcp_thread.cc
@@ -1,1 +1,0 @@
-../../libraries/tcp_daq/tcp_thread.cc

--- a/src/plugins/CDAQtcp/tcp_thread.h
+++ b/src/plugins/CDAQtcp/tcp_thread.h
@@ -1,1 +1,0 @@
-../../libraries/tcp_daq/tcp_thread.h

--- a/src/services/root_output/CMakeLists.txt
+++ b/src/services/root_output/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # Automatically set plugin name the same as the directory name
 # Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
-get_filename_component(PLUGIN_NAME . NAME)
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets


### PR DESCRIPTION
This mainly replaces the CMakeLists.txt files in the CDAQtcp and CDAQfile plugins to use the top-level macros.

Also:
- fixes bug in naming of root_output plugin.
- removes symlinks to tcp_thread.X files and instead gets them via tcp_daq library.