### PR TITLE
Fix double free the simple way

### DIFF
--- a/src/executables/jana4ml4fpga/CMakeLists.txt
+++ b/src/executables/jana4ml4fpga/CMakeLists.txt
@@ -13,7 +13,8 @@ message("{{JANA_INCLUDE_DIR}} ${JANA_INCLUDE_DIR}")
 
 add_executable(${PROJECT_NAME} ${block_tester_SRC})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR} ${JANA_INCLUDE_DIR})
-target_link_libraries(${PROJECT_NAME} ${JANA_LIB} evio rawdataparser Threads::Threads dl ${ROOT_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} evio rawdataparser JANA::jana2_static_lib  Threads::Threads dl ${ROOT_LIBRARIES})
+target_link_options(${PROJECT_NAME} PRIVATE -rdynamic)
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}  DESTINATION ${PROGRAM_OUTPUT_DIRECTORY})


### PR DESCRIPTION
This looks to be the simplest way to fix the double free at exit issue. This should work with JANA2 v2.0.9 since it forces linking the `jana4ml4fpga` executable against the static `libJANA.a`.