### PR TITLE
Use unique_ptr for m_hdevio in EventSources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Find packages
 find_package(JANA REQUIRED)
 find_package(ROOT REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(fmt REQUIRED)
 
 # Install to the top directory by default
 if( ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT} )

--- a/src/executables/jana4ml4fpga/CMakeLists.txt
+++ b/src/executables/jana4ml4fpga/CMakeLists.txt
@@ -1,23 +1,29 @@
-
 project(jana4ml4fpga)
 
 print_header(">>>>   E X E C U T A B L E S : ${PROJECT_NAME}   <<<<")
 
-file(GLOB block_tester_SRC
+file(GLOB jana4ml4fpga_SRC
         *.h
         *.cc
         )
 
-message("{JANA_LIB} ${JANA_LIB}")
-message("{{JANA_INCLUDE_DIR}} ${JANA_INCLUDE_DIR}")
+add_executable(${PROJECT_NAME} ${jana4ml4fpga_SRC})
 
-add_executable(${PROJECT_NAME} ${block_tester_SRC})
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR} ${JANA_INCLUDE_DIR})
-target_link_libraries(${PROJECT_NAME} evio rawdataparser JANA::jana2_static_lib  Threads::Threads dl ${ROOT_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC
+        ${CMAKE_SOURCE_DIR}
+        ${JANA_INCLUDE_DIR}
+        ${fmt_DIR}/../../../include
+        )
+
+target_link_libraries(${PROJECT_NAME}
+        JANA::jana2_static_lib
+        spdlog::spdlog fmt::fmt
+        evio rawdataparser Threads::Threads dl ${ROOT_LIBRARIES}
+        )
+
 target_link_options(${PROJECT_NAME} PRIVATE -rdynamic)
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}  DESTINATION ${PROGRAM_OUTPUT_DIRECTORY})
 
 remove_definitions()
-

--- a/src/executables/jana4ml4fpga/EVIOBlockedEventFileSource.cc
+++ b/src/executables/jana4ml4fpga/EVIOBlockedEventFileSource.cc
@@ -19,11 +19,10 @@ EVIOBlockedEventFileSource::DisentangleBlock(EVIOBlockedEvent &block, JEventPool
 }
 
 void EVIOBlockedEventFileSource::CloseEVIOFile() {
-    if (m_hdevio) {
-        m_hdevio->PrintStats(); // print status for debugging
-        LOG_INFO(m_logger) << "Closing EVIO file \"" << cur_file << "\"!" << LOG_END;
-        delete m_hdevio; /// FIXME (@davidl): if do not touch HDEVIO destructor, double free or corruption error
-    }
+    m_hdevio->PrintStats();
+    m_hdevio.reset();
+
+    LOG_INFO(m_logger) << "Closing EVIO file \"" << cur_file << "\"!" << LOG_END;
 }
 
 EVIOBlockedEventFileSource::~EVIOBlockedEventFileSource() {
@@ -42,7 +41,7 @@ void EVIOBlockedEventFileSource::OpenNextEVIOFile() {
     cur_file = m_filenames.back();
     m_filenames.pop_back();
 
-    m_hdevio = new HDEVIO(cur_file, true, 2);   // 2 for VERBOSE level
+    m_hdevio = std::make_unique<HDEVIO>(cur_file, true, 2);   // 2 for VERBOSE level
     if (!m_hdevio->is_open) {
         cerr << m_hdevio->err_mess.str() << endl;
         throw JException("Failed to open EVIO file: " + cur_file, __FILE__, __LINE__);  // throw exception indicating error
@@ -61,7 +60,7 @@ void EVIOBlockedEventFileSource::Initialize() {
 }
 
 JBlockedEventSource<EVIOBlockedEvent>::Status EVIOBlockedEventFileSource::NextBlock(EVIOBlockedEvent &block) {
-    LOG_INFO(m_logger) <<  "JBlockedEventSource::NextBlock" << LOG_END;
+    LOG_DEBUG(m_logger) <<  "JBlockedEventSource::NextBlock" << LOG_END;
 
     EVIOBlockedEventFileSource::Status status;
     m_buff = new uint32_t[m_buff_len];
@@ -93,7 +92,7 @@ JBlockedEventSource<EVIOBlockedEvent>::Status EVIOBlockedEventFileSource::NextBl
         if (m_hdevio->err_code == HDEVIO::HDEVIO_USER_BUFFER_TOO_SMALL) {
             m_buff_len = cur_len;
             status = Status::FailTryAgain;
-            LOG_INFO(m_logger) << "Block \"" << m_block_number << " HDEVIO_USER_BUFFER_TOO_SMALL" << LOG_END;
+            LOG_DEBUG(m_logger) << "Block \"" << m_block_number << " HDEVIO_USER_BUFFER_TOO_SMALL" << LOG_END;
         } else if (m_hdevio->err_code == HDEVIO::HDEVIO_EOF) {
             // Two situations: 1. open another file 2. no more files to open
             LOG_INFO(m_logger) << "No more blocks in \"" << cur_file << "\"!" << LOG_END;
@@ -109,7 +108,7 @@ JBlockedEventSource<EVIOBlockedEvent>::Status EVIOBlockedEventFileSource::NextBl
                 EVIOBlockedEventFileSource::OpenNextEVIOFile();
             }
         } else { // keep it ugly now
-            throw JException("Unhandled EVIO file read return status: " , __FILE__, __LINE__);
+            throw JException("Unhandled EVIO file read return status: ", __FILE__, __LINE__);
         }
     }
 

--- a/src/executables/jana4ml4fpga/EVIOBlockedEventFileSource.h
+++ b/src/executables/jana4ml4fpga/EVIOBlockedEventFileSource.h
@@ -51,7 +51,7 @@ private:
     std::vector<std::string> m_filenames;   // filenames to open, copied from cli inputs
     std::string cur_file;                   // current EVIO file to read
 
-    HDEVIO *m_hdevio = nullptr;
+    std::unique_ptr<HDEVIO> m_hdevio;
 
     uint32_t *m_buff = nullptr;             // buff to read EVIO block
     uint32_t m_buff_len = DEFAULT_READ_BUFF_LEN;

--- a/src/libraries/evio/HDEVIO.cc
+++ b/src/libraries/evio/HDEVIO.cc
@@ -103,8 +103,7 @@ HDEVIO::HDEVIO(string fname, bool read_map_file, int verbose):filename(fname),VE
 HDEVIO::~HDEVIO()
 {
 #ifdef USE_ASYNC_FILEBUF
-    _DBG_ << "Call HDEVIO destructor!" << ifs.std::ios::rdbuf() << std::endl;
-//    delete ifs.std::ios::rdbuf();   /// @davidl
+    delete ifs.std::ios::rdbuf();
 	ifs.std::ios::rdbuf(ifs.rdbuf());
 #endif
 	if(ifs.is_open()) ifs.close();

--- a/src/libraries/evio/HDEVIO.cc
+++ b/src/libraries/evio/HDEVIO.cc
@@ -103,7 +103,7 @@ HDEVIO::HDEVIO(string fname, bool read_map_file, int verbose):filename(fname),VE
 HDEVIO::~HDEVIO()
 {
 #ifdef USE_ASYNC_FILEBUF
-    delete ifs.std::ios::rdbuf();
+//    delete ifs.std::ios::rdbuf();  /// FIXME: comment out because jana4ml4fpga would not advance after reading one file
 	ifs.std::ios::rdbuf(ifs.rdbuf());
 #endif
 	if(ifs.is_open()) ifs.close();

--- a/src/plugins/CDAQfile/CDAQEVIOFileSource.cc
+++ b/src/plugins/CDAQfile/CDAQEVIOFileSource.cc
@@ -6,8 +6,6 @@
 
 #include "CDAQEVIOFileSource.h"
 
-#define DEFAULT_READ_BUFF_LEN 4000000
-
 using namespace std;
 using namespace std::chrono;
 
@@ -30,6 +28,7 @@ CDAQEVIOFileSource::~CDAQEVIOFileSource() {
         delete m_hdevio;
     }
 
+    delete[] m_buff;
     m_evio_filename = "";
 }
 
@@ -43,11 +42,12 @@ void CDAQEVIOFileSource::OpenEVIOFile(std::string filename) {
     m_log->info("Open EVIO file {} successfully", filename);
 }
 
-EVIOBlockedEvent CDAQEVIOFileSource::GetBlockFromBuffer(uint32_t *buffer, uint32_t event_len) {
+EVIOBlockedEvent CDAQEVIOFileSource::GetBlockFromBuffer(uint32_t event_len) {
     EVIOBlockedEvent block;
 
+    block.block_number = m_block_number++;
     block.swap_needed = m_hdevio->swap_needed;
-    block.data.insert(block.data.begin(), buffer, buffer + event_len);
+    block.data.insert(block.data.begin(), m_buff, m_buff + event_len);
 
     return block;
 }
@@ -57,69 +57,50 @@ EVIOBlockedEvent CDAQEVIOFileSource::GetBlockFromBuffer(uint32_t *buffer, uint32
  * Handle three cases: read_ok, HDEVIO::HDEVIO_USER_BUFFER_TOO_SMALL, HDEVIO::HDEVIO_EOF.
  */
 void CDAQEVIOFileSource::GetEvent(std::shared_ptr<JEvent> event) {
-    uint32_t block_counter = 1;
-    uint32_t buff_len = DEFAULT_READ_BUFF_LEN;
-    uint32_t* buff = new uint32_t[buff_len];
+    m_buff = new uint32_t[m_buff_len];
+    bool read_ok = m_hdevio->readNoFileBuff(m_buff, m_buff_len);
+    uint32_t cur_len = m_hdevio->last_event_len;
 
-    while (m_hdevio->readNoFileBuff(buff, buff_len) || m_hdevio->err_code == HDEVIO::HDEVIO_USER_BUFFER_TOO_SMALL) {
-        uint32_t cur_len = m_hdevio->last_event_len;
-        m_log->info("Read block {} status: {}", block_counter, m_hdevio->err_code);
-
-        //Buffer is too small, enlarge buffer
-        if (m_hdevio->err_code == HDEVIO::HDEVIO_USER_BUFFER_TOO_SMALL) {
-            delete[] buff;
-            buff_len = cur_len;
-            buff = new uint32_t[buff_len];
-            continue;
+    // Handle not read_ok
+    if (not read_ok) {
+        if (m_hdevio->err_code == HDEVIO::HDEVIO_EOF) {
+            return ReturnStatus::Finished;
+        } else if (m_hdevio->err_code == HDEVIO::HDEVIO_USER_BUFFER_TOO_SMALL) {
+            m_buff_len = cur_len;
+            delete[] m_buff;
+            return ReturnStatus::TryAgain;
+        } else {
+            throw JException("Unhandled EVIO file reading return status " + m_hdevio->err_code, __FILE__, __LINE__);
         }
-
-        EVIOBlockedEvent cur_block = GetBlockFromBuffer(buff, cur_len);
-        cur_block.block_number = block_counter++;
-
-        // Get events from current block
-        EVIOBlockedEventParser parser;
-        auto events = parser.ParseEVIOBlockedEvent(cur_block, event);
-
-        // Trace events for debugging
-        m_log->info("Parsed block {} had {} events, swap_needed={}",
-                     cur_block.block_number, events.size(), cur_block.swap_needed);
-        for (size_t i = 0; i < events.size(); i++) {
-            auto &parsed_event = events[i];
-            m_log->trace("  Event #{} got event-number={}:", i, parsed_event->GetEventNumber());
-
-            for (auto factory: parsed_event->GetFactorySet()->GetAllFactories()) {
-                m_log->trace("    Factory = {:<30}  NumObjects = {}", factory->GetObjectName(),
-                             factory->GetNumObjects());
-            }
-        }
-
-        // Reset buff to prevent memory leakage
-        delete[] buff;
-        buff_len = DEFAULT_READ_BUFF_LEN;
-        buff = new uint32_t[buff_len];
     }
 
-    // Handle HDEVIO::HDEVIO_EOF
-    if (m_hdevio->err_code == HDEVIO::HDEVIO_EOF) {
-        throw RETURN_STATUS::kNO_MORE_EVENTS;
-    } else {
-        throw JException("Unhandled EVIO file reading return status " + m_hdevio->err_code, __FILE__, __LINE__);
+    EVIOBlockedEvent cur_block = GetBlockFromBuffer(cur_len);
+
+    // Get events from current block
+    EVIOBlockedEventParser parser;
+    auto events = parser.ParseEVIOBlockedEvent(cur_block, event);
+    m_log->info("Parsed block {} had {} events, swap_needed={}",
+                cur_block.block_number, events.size(), cur_block.swap_needed);
+    for (size_t i = 0; i < events.size(); i++) {
+        auto &parsed_event = events[i];
+        m_log->trace("  Event #{} got event-number={}:", i, parsed_event->GetEventNumber());
+
+        for (auto factory: parsed_event->GetFactorySet()->GetAllFactories()) {
+            m_log->trace("    Factory = {:<30}  NumObjects = {}", factory->GetObjectName(),
+                         factory->GetNumObjects());
+        }
     }
 
-    m_log->info("Parsed {} blocks from {}", block_counter - 1, m_evio_filename);
-
-    // clean buffer
-    delete[] buff;
+    // Reset buff to prevent memory leakage
+    delete[] m_buff;
+    m_buff_len = DEFAULT_READ_BUFF_LEN;
+    return;
 }
 
 void CDAQEVIOFileSource::Open() {
-    JApplication *app = GetApplication();
-
-    m_log = app->GetService<Log_service>()->logger(GetPluginName());  // init spdlog
+    InitLogger("CDAQEVIOFileSource");  // init spdlog
     m_evio_filename = GetResourceName();
-
     m_log->info("GetResourceName() = {}", m_evio_filename);
-
     CDAQEVIOFileSource::OpenEVIOFile(m_evio_filename);
 }
 
@@ -139,6 +120,7 @@ double JEventSourceGeneratorT<CDAQEVIOFileSource>::CheckOpenable(std::string res
     /// Returning a confidence <- {0.0, 1.0} is perfectly OK!
 
     if (resource_name.find(".evio") != std::string::npos) return 0.5;
+    return 0;
 
 //    return (resource_name == "CDAQEVIOFileSource") ? 1.0 : 0.0;
 

--- a/src/plugins/CDAQfile/CDAQEVIOFileSource.cc
+++ b/src/plugins/CDAQfile/CDAQEVIOFileSource.cc
@@ -76,7 +76,7 @@ void CDAQEVIOFileSource::GetEvent(std::shared_ptr<JEvent> event) {
     // Get events from current block
     EVIOBlockedEventParser parser;
     auto events = parser.ParseEVIOBlockedEvent(cur_block, event);
-    m_log->info("Parsed block {} had {} events, swap_needed={}",
+    m_log->debug("Parsed block {} had {} events, swap_needed={}",
                 cur_block.block_number, events.size(), cur_block.swap_needed);
     for (size_t i = 0; i < events.size(); i++) {
         auto &parsed_event = events[i];

--- a/src/plugins/CDAQfile/CDAQEVIOFileSource.h
+++ b/src/plugins/CDAQfile/CDAQEVIOFileSource.h
@@ -24,6 +24,8 @@
 
 #include <extensions/spdlog/SpdlogMixin.h>
 
+#define DEFAULT_READ_BUFF_LEN 4000000
+
 class CDAQEVIOFileSource :
         public JEventSource,
         public spdlog::extensions::SpdlogMixin<CDAQEVIOFileSource>
@@ -43,12 +45,15 @@ public:
 
 private:
     std::string m_evio_filename = "";
-    HDEVIO *m_hdevio = nullptr;
-    std::shared_ptr<spdlog::logger> m_log;
+    unique_ptr<HDEVIO> m_hdevio;
+
+    uint32_t *m_buff = nullptr;
+    uint32_t static const m_buff_len = DEFAULT_READ_BUFF_LEN;
+    int m_block_number = 1;
 
     void OpenEVIOFile(std::string filename);
 
-    EVIOBlockedEvent GetBlockFromBuffer(uint32_t *buffer, uint32_t event_len);
+    EVIOBlockedEvent GetBlockFromBuffer(uint32_t event_len);
 };
 
 template <>

--- a/src/plugins/CDAQfile/CDAQEVIOFileSource.h
+++ b/src/plugins/CDAQfile/CDAQEVIOFileSource.h
@@ -48,7 +48,7 @@ private:
     unique_ptr<HDEVIO> m_hdevio;
 
     uint32_t *m_buff = nullptr;
-    uint32_t static const m_buff_len = DEFAULT_READ_BUFF_LEN;
+    uint32_t m_buff_len = DEFAULT_READ_BUFF_LEN;
     int m_block_number = 1;
 
     void OpenEVIOFile(std::string filename);


### PR DESCRIPTION
- [x] Fix the problem that when "CDAQfile" plugin is added, no processor is launched. I think we should this plugin instead of single_file_evio because I see different behavours for the same file.
- [x] Modify `EVIOBlockedEventFileSource` to use unique_ptr to hold HDEVIO files
- [x] Add spdlog/fmt dependency to jana4ml4fpga  

### Call `jana4ml4fpga` in 2 ways to open multiple EVIO files
- Use EventSource()
```
[hdtrdops@gluon200 JANA4ML4FPGA]$ ./install/bin/jana4ml4fpga -Pexample_evio_analysis:LogLevel=trace -Pplugins=log,root_output,example_evio_analysis,CDAQfile /gluonraid3/data4/rawdata/trd/DATA/hd_rawdata_002539_000.evio /gluonraid3/data4/rawdata/trd/DATA/hd_rawdata_002539_002.evio

2023-03-09 04:08:39.932] [example_evio_analysis] [trace] TestEventProcessor event
[INFO] Status: 192 events processed  476.3 Hz (476.3 Hz avg)
[INFO] All workers have stopped.
[INFO] Merging threads ...
[INFO] JArrow: Finalized JEventProcessor ''
[INFO] Event processing ended.
[INFO] JArrowProcessingController: Final Report
  Thread team size [count]:    1
  Total uptime [s]:            0.4031
  Uptime delta [s]:            0.4031
  Completed events [count]:    192
  Inst throughput [Hz]:        476
  Avg throughput [Hz]:         476
  Sequential bottleneck [Hz]:  573
  Parallel bottleneck [Hz]:    7.33e+04
  Efficiency [0..1]:           0.832

  +--------------------------+------------+--------+-----+---------+-------+--------+---------+-------------+
  |           Name           |   Status   |  Type  | Par | Threads | Chunk | Thresh | Pending |  Completed  |
  +--------------------------+------------+--------+-----+---------+-------+--------+---------+-------------+
  | sources                  | Finished   | Source |  F  |       0 |    40 |      - |       - |         192 |
  | processors               | Finished   | Sink   |  T  |       0 |     1 |     80 |       0 |         192 |
  +--------------------------+------------+--------+-----+---------+-------+--------+---------+-------------+
  +--------------------------+-------------+--------------+----------------+--------------+----------------+
  |           Name           | Avg latency | Inst latency | Queue latency  | Queue visits | Queue overhead | 
  |                          | [ms/event]  |  [ms/event]  |   [ms/visit]   |    [count]   |     [0..1]     | 
  +--------------------------+-------------+--------------+----------------+--------------+----------------+
  | sources                  |        1.75 |         1.39 |       0.000449 |          193 |       0.000258 |
  | processors               |      0.0136 |       0.0114 |       0.000226 |          960 |         0.0766 |
  +--------------------------+-------------+--------------+----------------+--------------+----------------+
  +----+----------------------+-------------+------------+-----------+----------------+------------------+
  | ID | Last arrow name      | Useful time | Retry time | Idle time | Scheduler time | Scheduler visits |
  |    |                      |     [ms]    |    [ms]    |    [ms]   |      [ms]      |     [count]      |
  +----+----------------------+-------------+------------+-----------+----------------+------------------+
  |  0 | idle                 |       0.131 |          0 |         0 |         0.0002 |              385 |
  +----+----------------------+-------------+------------+-----------+----------------+------------------+


```

- Use EVIOBlockedEventFileSource with "-t" option
```
 ./install/bin/jana4ml4fpga -Pexample_evio_analysis:LogLevel=trace -t -Pplugins=log,root_output,example_evio_analysis,CDAQfile /gluonraid3/data4/rawdata/trd/DATA/hd_rawdata_002539_000.evio /gluonraid3/data4/rawdata/trd/DATA/hd_rawdata_002539_002.evio
...
[INFO] Block 192 read_ok
/home/hdtrdops/GemTrd_2023/JANA4ML4FPGA/src/executables/jana4ml4fpga/EVIOBlockProcessor.cc:20
[2023-03-09 04:21:54.819] [example_evio_analysis] [trace] TestEventProcessor event
[INFO] No more blocks in "/gluonraid3/data4/rawdata/trd/DATA/hd_rawdata_002539_000.evio"!

```