### PR TITLE
Add parsers for CODA Physics bank, TS bank and Df250WindowRawData

### DIFF
--- a/src/libraries/rawdataparser/DCODAEventInfo.h
+++ b/src/libraries/rawdataparser/DCODAEventInfo.h
@@ -1,0 +1,38 @@
+// $Id$
+// $HeadURL$
+//
+//    File: DCODAEventInfo.h
+// Created: Wed Oct 15 11:35:43 EDT 2014
+// Creator: davidl (on Darwin harriet.local 13.3.0 i386)
+//
+
+#ifndef _DCODAEventInfo_
+#define _DCODAEventInfo_
+
+#include <JANA/JObject.h>
+// using namespace jana;
+
+class DCODAEventInfo:public JObject{
+	public:
+		JOBJECT_PUBLIC(DCODAEventInfo);
+		
+		uint32_t run_number;
+		uint32_t run_type;
+		uint64_t event_number;
+		uint16_t event_type;
+		uint64_t avg_timestamp;
+		
+		// This method is used primarily for pretty printing
+		// the second argument to AddString is printf style format
+		void Summarize(JObjectSummary& summary) const override {
+			summary.add(run_number,    NAME_OF(run_number), "%d");
+			summary.add(run_type,      NAME_OF(run_type), "%d");
+			summary.add(event_number,  NAME_OF(event_number), "%ld");
+			summary.add(event_type,    NAME_OF(event_type), "%d");
+			summary.add(avg_timestamp, NAME_OF(avg_timestamp), "%ld");
+		}
+		
+};
+
+#endif // _DCODAEventInfo_
+

--- a/src/libraries/rawdataparser/Df250WindowRawData.h
+++ b/src/libraries/rawdataparser/Df250WindowRawData.h
@@ -1,0 +1,38 @@
+// $Id$
+// $HeadURL$
+//
+//    File: Df125WindowRawData.h
+// Created: Thu Jun 19 20:48:04 EDT 2014
+// Creator: davidl (on Darwin harriet.jlab.org 13.2.0 i386)
+//
+
+#pragma once
+
+#include <rawdataparser/DDAQAddress.h>
+
+class Df250WindowRawData:public DDAQAddress{
+
+	/// Holds window raw data samples for one event in
+	/// one channel of a single f250 Flash ADC module.
+	
+	public:
+		JOBJECT_PUBLIC(Df250WindowRawData);
+	
+		Df250WindowRawData(uint32_t rocid=0, uint32_t slot=0, uint32_t channel=0, uint32_t itrigger=0):DDAQAddress(rocid, slot, channel, itrigger),invalid_samples(false),overflow(false){}
+	
+		std::vector<uint16_t> samples;// from Window Raw Data words 2-N (each word contains 2 samples)
+		bool invalid_samples;    // true if any sample's "not valid" bit set
+		bool overflow;           // true if any sample's "overflow" bit set
+
+		// This method is used primarily for pretty printing
+		// the second argument to AddString is printf style format
+		void Summarize(JObjectSummary& summary) const override {
+			DDAQAddress::Summarize(summary);
+			summary.add(samples.size(), "Nsamples", "%d");
+			summary.add(invalid_samples, NAME_OF(invalid_samples), "%d");
+			summary.add(overflow, NAME_OF(overflow), "%d");
+		}
+
+};
+
+

--- a/src/libraries/rawdataparser/EVIOBlockedEventParser.h
+++ b/src/libraries/rawdataparser/EVIOBlockedEventParser.h
@@ -23,7 +23,7 @@
 #include <rawdataparser/Df250PulseTime.h>
 #include <rawdataparser/Df250PulsePedestal.h>
 #include <rawdataparser/Df250PulseData.h>
-// #include <rawdataparser/Df250WindowRawData.h>
+#include <rawdataparser/Df250WindowRawData.h>
 #include <rawdataparser/Df125Config.h>
 #include <rawdataparser/Df125TriggerTime.h>
 #include <rawdataparser/Df125PulseIntegral.h>
@@ -38,7 +38,7 @@
 // #include <rawdataparser/DF1TDCTriggerTime.h>
 #include <rawdataparser/DCAEN1290TDCConfig.h>
 // #include <rawdataparser/DCAEN1290TDCHit.h>
-// #include <rawdataparser/DCODAEventInfo.h>
+#include <rawdataparser/DCODAEventInfo.h>
 #include <rawdataparser/DCODAControlEvent.h>
 #include <rawdataparser/DCODAROCInfo.h>
 // #include <rawdataparser/Df250Scaler.h>
@@ -86,6 +86,7 @@ public:
     void ParseControlEvent(uint32_t* &iptr, uint32_t *iend);
     void ParsePhysicsBank(uint32_t* &iptr, uint32_t *iend);
     void ParseCDAQBank(uint32_t* &iptr, uint32_t *iend);
+    void ParseBuiltTriggerBank(uint32_t* &iptr, uint32_t *iend);
     void ParseDataBank(uint32_t* &iptr, uint32_t *iend);
 
     void ParseCAEN1190(uint32_t rocid, uint32_t *&iptr, uint32_t *iend);
@@ -100,6 +101,7 @@ public:
 
     void MakeDGEMSRSWindowRawData(JEvent *event, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t apv_id, vector<int>rawData16bits);
     void Parsef250Bank(uint32_t rocid, uint32_t *&iptr, uint32_t *iend);
+    void MakeDf250WindowRawData(JEvent *event, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t* &iptr);
     void Parsef125Bank(uint32_t rocid, uint32_t *&iptr, uint32_t *iend);
     void MakeDf125WindowRawData(JEvent *event, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t* &iptr);
     void ParseF1TDCBank(uint32_t rocid, uint32_t *&iptr, uint32_t *iend);


### PR DESCRIPTION
This copies over the parsers for some banks that were left out originally from the parser. This should things work with reading CODA data files now.