### PR TITLE
Fix unknown outer bank type 0

### DIFF
--- a/src/libraries/rawdataparser/EVIOBlockedEventParser.cc
+++ b/src/libraries/rawdataparser/EVIOBlockedEventParser.cc
@@ -192,6 +192,7 @@ void EVIOBlockedEventParser::ParseBank(uint32_t *istart, uint32_t *iend)
 
 			default:
 				_DBG_ << "Unknown outer EVIO bank tag: " << std::hex << tag << std::dec << std::endl;
+				DumpBinary(iptr, nullptr, 20, nullptr);
 				iptr = &iptr[event_len+1];
 				if(event_len<1) iptr = iend;		
 		}


### PR DESCRIPTION
This fixes the problem identified by Cissie in issue #32 and by Dmitry in issue #31.

It looks like the resolution of this was going to be deprecating or removing the code rather than fixing it, but then issue #31 31 was reopened today. Presumably since it has not yet been resolved in the code. I'm resolving it here since it is a simple fix so issue #31 can be closed permenantly.