### PR TITLE
Fix double corruption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,16 @@ include_directories(${CMAKE_SOURCE_DIR}/src)
 # For peer plugins the later is OK, but for libraries <tcp_daq/tcp_event.h> is better
 include_directories(${CMAKE_SOURCE_DIR}/src/libraries)
 
+#Add clang sanitizers
+#if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+#    # Enable sanitizers
+#    message(STATUS "Clang sanitizers are enabled")
+#    set(SANITIZE_FLAGS "-fsanitize=address,undefined")
+#    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZE_FLAGS}")
+#    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZE_FLAGS}")
+#endif()
+
+
 # ---------------------------------------------------------------------------
 print_grand_header("    B U I L D   J A N A 4 M L 4 F P G A   P A R T S    ")
 # ---------------------------------------------------------------------------

--- a/src/libraries/evio/CMakeLists.txt
+++ b/src/libraries/evio/CMakeLists.txt
@@ -12,7 +12,7 @@ file(GLOB lib_evio_SRC
 
 set(LIBRARY_NAME evio)
 
-add_library(${LIBRARY_NAME} STATIC ${lib_evio_SRC})
+add_library(${LIBRARY_NAME} SHARED ${lib_evio_SRC})
 set_target_properties(${LIBRARY_NAME}  PROPERTIES PREFIX "lib" OUTPUT_NAME "EVIO")
 target_include_directories(${LIBRARY_NAME}  PUBLIC ${CMAKE_SOURCE_DIR} ${JANA_INCLUDE_DIR})
 target_link_libraries(${LIBRARY_NAME}  ${JANA_LIB})


### PR DESCRIPTION
With this simple fix the corruption are gone. 

ODR violations are still bad but there is #38 for that. 

Interesting thing is that if I run `jana ...` double corruption occurs. But `jana4ml4fpga ...` exits correctly