### PR TITLE
Clean up plugins/CDAQfile

### DIFF
--- a/src/plugins/CDAQfile/CDAQEVIOFileSource.cc
+++ b/src/plugins/CDAQfile/CDAQEVIOFileSource.cc
@@ -3,11 +3,8 @@
 //
 
 #include <rawdataparser/EVIOBlockedEventParser.h>
-#include <rawdataparser/CDaqTCPevent.h>
-
 
 #include "CDAQEVIOFileSource.h"
-
 
 using namespace std;
 using namespace std::chrono;
@@ -15,20 +12,21 @@ using namespace std::chrono;
 /**
  * Constructor
  */
-CDAQEVIOFileSource::CDAQEVIOFileSource(std::string resource_name, JApplication *app) : JEventSource(resource_name, app)
-{
+CDAQEVIOFileSource::CDAQEVIOFileSource(std::string resource_name, JApplication *app) : JEventSource(resource_name,
+                                                                                                    app) {
     SetTypeName(NAME_OF_THIS); // Provide JANA with class name
 }
+
 /**
  * Destructor
  */
 CDAQEVIOFileSource::~CDAQEVIOFileSource() {
-    if(m_hdevio) {
+    if (m_hdevio) {
         m_hdevio->PrintStats();
         m_hdevio.reset();
     }
 
-    if(m_buff) delete[] m_buff;
+    if (m_buff) delete[] m_buff;
 
     m_evio_filename = "";
 }
@@ -36,35 +34,23 @@ CDAQEVIOFileSource::~CDAQEVIOFileSource() {
 void CDAQEVIOFileSource::OpenEVIOFile(std::string filename) {
     m_hdevio = std::make_unique<HDEVIO>(filename, true, 2);   // 2 for VERBOSE level
     if (!m_hdevio->is_open) {
-        cerr <<m_hdevio->err_mess.str() << endl;
+        cerr << m_hdevio->err_mess.str() << endl;
         throw JException("Failed to open EVIO file: " + filename, __FILE__, __LINE__);
         // throw exception indicating error
     }
     m_log->info("Open EVIO file {} successfully", filename);
 }
 
-// EVIOBlockedEvent* CDAQEVIOFileSource::GetBlockFromBuffer(uint32_t event_len) {
-//     auto block = new EVIOBlockedEvent();
-
-//     block->block_number = m_block_number++;
-//     block->swap_needed = m_hdevio->swap_needed;
-//     block->data.insert(block->data.begin(), m_buff, m_buff + event_len);
-
-//     return block;
-// }
-
 /**
  * Read the evio file with HDEVIO::readNoFileBuff().
  * Handle three cases: read_ok, HDEVIO::HDEVIO_USER_BUFFER_TOO_SMALL, HDEVIO::HDEVIO_EOF.
  */
-void CDAQEVIOFileSource::GetEvent(std::shared_ptr<JEvent> event) {
+void CDAQEVIOFileSource::GetEvent(std::shared_ptr <JEvent> event) {
 
     auto block = new EVIOBlockedEvent();
     block->data.resize(m_buff_len);
 
-    // m_buff = new uint32_t[m_buff_len];
     bool read_ok = m_hdevio->readNoFileBuff(block->data.data(), block->data.capacity());
-    // bool read_ok = m_hdevio->readNoFileBuff(m_buff, m_buff_len);
     uint32_t cur_len = m_hdevio->last_event_len;
 
     // Handle not read_ok
@@ -74,8 +60,6 @@ void CDAQEVIOFileSource::GetEvent(std::shared_ptr<JEvent> event) {
         } else if (m_hdevio->err_code == HDEVIO::HDEVIO_USER_BUFFER_TOO_SMALL) {
             m_buff_len = cur_len;
             delete block;
-            // delete[] m_buff;
-            // m_buff = nullptr;
             throw RETURN_STATUS::kTRY_AGAIN;
         } else {
             throw JException("Unhandled EVIO file reading return status " + m_hdevio->err_code, __FILE__, __LINE__);
@@ -86,26 +70,22 @@ void CDAQEVIOFileSource::GetEvent(std::shared_ptr<JEvent> event) {
     block->swap_needed = m_hdevio->swap_needed;
     block->data.resize(cur_len);
 
-    event->Insert( block );
+    event->Insert(block);
 
     // Get events from current block
     EVIOBlockedEventParser parser;
     parser.Configure(m_parser_config);
     auto events = parser.ParseEVIOBlockedEvent(*block, event);
-    m_log->debug("Parsed block {} had {} events, swap_needed={}", block->block_number, events.size(), block->swap_needed);
+    m_log->debug("Parsed block {} had {} events, swap_needed={}", block->block_number, events.size(),
+                 block->swap_needed);
+    // Print parsed event info
     for (size_t i = 0; i < events.size(); i++) {
         auto &parsed_event = events[i];
         m_log->trace("  Event #{} got event-number={}:", i, parsed_event->GetEventNumber());
-
         for (auto factory: parsed_event->GetFactorySet()->GetAllFactories()) {
             m_log->trace("    Factory = {:<30}  NumObjects = {}", factory->GetObjectName(), factory->GetNumObjects());
         }
     }
-
-    // Reset buff to prevent memory leakage
-    // delete[] m_buff;
-    // m_buff = nullptr;
-    // m_buff_len = DEFAULT_READ_BUFF_LEN;
 }
 
 void CDAQEVIOFileSource::Open() {
@@ -114,7 +94,8 @@ void CDAQEVIOFileSource::Open() {
     m_log->info("GetResourceName() = {}", m_evio_filename);
     CDAQEVIOFileSource::OpenEVIOFile(m_evio_filename);
 
-    GetApplication()->SetDefaultParameter("daq:srs_window_raw:ntsamples", m_parser_config.NSAMPLES_GEMSRS, "Number of GEM SRS time samples per APV");
+    GetApplication()->SetDefaultParameter("daq:srs_window_raw:ntsamples", m_parser_config.NSAMPLES_GEMSRS,
+                                          "Number of GEM SRS time samples per APV");
 }
 
 std::string CDAQEVIOFileSource::GetDescription() {
@@ -133,4 +114,3 @@ double JEventSourceGeneratorT<CDAQEVIOFileSource>::CheckOpenable(std::string res
     if (resource_name.find(".evio") != std::string::npos) return 0.5;
     return 0;
 }
-

--- a/src/plugins/CDAQfile/CDAQEVIOFileSource.h
+++ b/src/plugins/CDAQfile/CDAQEVIOFileSource.h
@@ -28,39 +28,33 @@
 
 class CDAQEVIOFileSource :
         public JEventSource,
-        public spdlog::extensions::SpdlogMixin<CDAQEVIOFileSource>
-        {
+        public spdlog::extensions::SpdlogMixin<CDAQEVIOFileSource> {
 
 public:
 
-    CDAQEVIOFileSource(std::string resource_name, JApplication* app);
+    CDAQEVIOFileSource(std::string resource_name, JApplication *app);
 
     virtual ~CDAQEVIOFileSource();
 
     void Open() override;
 
-    void GetEvent(std::shared_ptr<JEvent>);
+    void GetEvent(std::shared_ptr <JEvent>);
 
     static std::string GetDescription();
 
 private:
     std::string m_evio_filename = "";
-    std::unique_ptr<HDEVIO> m_hdevio;
+    std::unique_ptr <HDEVIO> m_hdevio;
     EVIOBlockedEventParserConfig m_parser_config;
 
     uint32_t *m_buff = nullptr;
     uint32_t m_buff_len = DEFAULT_READ_BUFF_LEN;
     int m_block_number = 1;
 
-
     void OpenEVIOFile(std::string filename);
-
-    // EVIOBlockedEvent* GetBlockFromBuffer(uint32_t event_len);
-
-
 };
 
-template <>
+template<>
 double JEventSourceGeneratorT<CDAQEVIOFileSource>::CheckOpenable(std::string);
 
 #endif //JANA4ML4FPGA_CDAQEVIOFILESOURCE_H

--- a/src/plugins/CDAQfile/CDAQfile.cc
+++ b/src/plugins/CDAQfile/CDAQfile.cc
@@ -5,7 +5,7 @@
 
 #include "CDAQEVIOFileSource.h"
 
-// put a real path for simplicity
+// put a real path for simplicity (on gluon200)
 /*
  * [hdtrdops@gluon200 ~]$ ls /gluonraid3/data4/rawdata/trd/DATA/hd_rawdata_002539_00
 hd_rawdata_002539_000.evio  hd_rawdata_002539_003.evio  hd_rawdata_002539_006.evio


### PR DESCRIPTION
This should be done within PR#51, but it's not too late to do it now.

- Delete some commented-out code.
- Remove a header file in CDAQWVIOFileSource.cc. 

### Test 
It does not influence the functionality following David'd cdaq 3-process guide on `gluon200` machine.